### PR TITLE
Bump PHP requirement to ^8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "type": "flarum-extension",
     "license": "MIT",
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "flarum/core": "^2.0.0-beta"
     },
     "authors": [


### PR DESCRIPTION
## Summary

`flarum/core` `v2.0.0-rc.1` requires PHP `^8.3`, so the post-merge CI on master fails to resolve dependencies with our `^8.2` requirement:

> Root composer.json requires flarum/core ^2.0.0-beta -> satisfiable by flarum/core[v2.0.0-rc.1].
> flarum/core v2.0.0-rc.1 requires php ^8.3 -> your php version (8.2.30) does not satisfy that requirement.

Bumps the constraint from `^8.2` to `^8.3` to match.

## Test plan

- [ ] CI on this branch resolves composer dependencies and passes