### PR TITLE
Pin reusable workflows to flarum/framework@2.x

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -8,7 +8,7 @@ on: [workflow_dispatch, push, pull_request]
 
 jobs:
   run:
-    uses: flarum/framework/.github/workflows/REUSABLE_backend.yml@main
+    uses: flarum/framework/.github/workflows/REUSABLE_backend.yml@2.x
     with:
       enable_backend_testing: false
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -8,7 +8,7 @@ on: [workflow_dispatch, push, pull_request]
 
 jobs:
   run:
-    uses: flarum/framework/.github/workflows/REUSABLE_frontend.yml@main
+    uses: flarum/framework/.github/workflows/REUSABLE_frontend.yml@2.x
     with:
       enable_bundlewatch: false
       enable_prettier: true


### PR DESCRIPTION
## Summary

Fixes the post-merge CI failure on master where composer install couldn't satisfy `flarum/core ^2.0.0-beta` (which resolves to `v2.0.0-rc.1`, requiring PHP `^8.3`):

> Root composer.json requires php ^8.3 but your php version (8.2.30) does not satisfy that requirement.

The default branch on `flarum/framework` is `2.x`, not `main`. The reusable workflow at `@main` is stale (last commit `29da25d`, PHP `8.2` hardcoded), while the one at `@2.x` uses PHP `8.5`.

Bumps both `backend.yml` and `frontend.yml` to reference `@2.x`.

## Test plan

- [ ] CI on this branch resolves composer dependencies and passes